### PR TITLE
fix(ios): set container frame to screen bounds

### DIFF
--- a/src/ios/LottieSplashScreen.swift
+++ b/src/ios/LottieSplashScreen.swift
@@ -115,14 +115,11 @@ import Lottie
         let parentView = viewController.view
         parentView?.isUserInteractionEnabled = false
 
-        animationViewContainer = UIView(frame: (parentView?.bounds)!)
+        animationViewContainer = UIView(frame: (UIScreen.main.bounds))
         animationViewContainer?.layer.zPosition = 1
 
         let backgroundColor = getUIModeDependentPreference(basePreferenceName: "LottieBackgroundColor", defaultValue: "#ffffff")
 
-        animationViewContainer?.autoresizingMask = [
-            .flexibleWidth, .flexibleHeight, .flexibleTopMargin, .flexibleLeftMargin, .flexibleBottomMargin, .flexibleRightMargin
-        ]
         animationViewContainer?.backgroundColor = UIColor(hex: backgroundColor)
     }
 


### PR DESCRIPTION
`parentView` reports bounds of (0, 0, 0, 0) (perhaps is not defined?)

`autoresizingMask` makes container inset
and makes animation appear in right bottom corner